### PR TITLE
change visibility of SourceLocator.getClassesUnder

### DIFF
--- a/src/main/java/soot/SourceLocator.java
+++ b/src/main/java/soot/SourceLocator.java
@@ -303,7 +303,7 @@ public class SourceLocator {
     return getClassesUnder(aPath, "");
   }
 
-  private List<String> getClassesUnder(String aPath, String prefix) {
+  public List<String> getClassesUnder(String aPath, String prefix) {
     List<String> classes = new ArrayList<String>();
     ClassSourceType cst = getClassSourceType(aPath);
 


### PR DESCRIPTION
This method is useful when the input folder is not the root package folder.